### PR TITLE
Fixing link errors,open() adding a 3rd argument and make install

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,7 +5,7 @@ FAST INSTALL
         CONFIG=Release CFLAGS='-Wno-narrowing' make -j8
 	cd ../../../../src
 	make -f Makefile.linux -j8
-	make install
+	(sudo) make -f Makefile.linux install
 
 
 

--- a/juce_1_44/juce/build/linux/platform_specific_code/juce_linux_Threads.cpp
+++ b/juce_1_44/juce/build/linux/platform_specific_code/juce_linux_Threads.cpp
@@ -389,7 +389,7 @@ InterProcessLock::InterProcessLock (const String& name_) throw()
     const File temp (tempDir.getChildFile (name));
     temp.create();
 
-    internal = (void*) open (temp.getFullPathName().toUTF8(), 'a');
+    internal = (void*) open (temp.getFullPathName().toUTF8(), 'a', 0600);
 }
 
 InterProcessLock::~InterProcessLock() throw()

--- a/src/Makefile.linux
+++ b/src/Makefile.linux
@@ -109,7 +109,7 @@ LDFLAGS= $(ADDITIONALLDFLAGS)  -lvorbisfile
 CPPFLAGS := -MD -D "LINUX=1" -I "/usr/include" -I$(JUCE)  -DTEMPDIR=\"$(TEMPDIR)\" $(CFLAGS)
 CFLAGS	 += $(CPPFLAGS)
 CXXFLAGS := $(CFLAGS)
-LDFLAGS += -L$(BINDIR) -L$(LIBDIR) -L "/usr/X11R6/lib/" -L "../../../bin" -lfreetype -lpthread -lX11 -lXext -lGL  -lXinerama -lasound -ljuce
+LDFLAGS += -L$(BINDIR) -L$(LIBDIR) -L "/usr/include/X11/" -L "../../../bin" -ljuce -lfreetype -ldl -lpthread -lX11 -lXext -lGL  -lXinerama -lasound 
 #_debug
 
 


### PR DESCRIPTION
Trying to build on Linux(ubuntu 18) was giving me some errors. After these changes building went successful.  The only small issue I have is that in order to move the mammut window I have to maximize it first and then grab it and move it across the screen..