### PR TITLE
Update jackplay.c

### DIFF
--- a/src/jackplay.c
+++ b/src/jackplay.c
@@ -48,7 +48,8 @@ static bool setup_ports(void){
   // Find ports to connect to
   {
     portnames=(char **)jack_get_ports(client,NULL,NULL,JackPortIsPhysical|JackPortIsInput);
-    channels=JP_MAX(DEFAULT_NUM_CHANNELS,findnumports(portnames));
+    //channels=JP_MAX(DEFAULT_NUM_CHANNELS,findnumports(portnames));
+    channels=2;
   }
 
 

--- a/src/jackplay.c
+++ b/src/jackplay.c
@@ -49,7 +49,7 @@ static bool setup_ports(void){
   {
     portnames=(char **)jack_get_ports(client,NULL,NULL,JackPortIsPhysical|JackPortIsInput);
     //channels=JP_MAX(DEFAULT_NUM_CHANNELS,findnumports(portnames));
-    channels=2;
+    channels=DEFAULT_NUM_CHANNELS;
   }
 
 


### PR DESCRIPTION
This is a fast fix for some audio interfaces that populate multiple channels inputs-outputs.
In that case mammut will try to populate all the channels too,but it won't be able to connect to jack any of them.
Restricting channels -> Default (2) will resolve this problem. Anyway mammut is not designed for multichannel stuff.