### PR TITLE
Add fix for JUCE compilation on modern GCC, add warning about linking for Jack on distributions using Pipewire to Makefile.linux

### DIFF
--- a/juce_5_3_2/JuceLibraryCode/modules/juce_graphics/native/juce_freetype_Fonts.cpp
+++ b/juce_5_3_2/JuceLibraryCode/modules/juce_graphics/native/juce_freetype_Fonts.cpp
@@ -353,8 +353,8 @@ private:
     bool getGlyphShape (Path& destShape, const FT_Outline& outline, const float scaleX)
     {
         const float scaleY = -scaleX;
-        const short* const contours = outline.contours;
-        const char* const tags = outline.tags;
+        const unsigned short* const contours = outline.contours;
+        const unsigned char* const tags = outline.tags;
         const FT_Vector* const points = outline.points;
 
         for (int c = 0; c < outline.n_contours; ++c)

--- a/src/Makefile.linux
+++ b/src/Makefile.linux
@@ -45,6 +45,15 @@ CC=$(GCC)
 
 # 5.
 #--------------------
+# Pipewire serves as a modern alternative to jack on some
+# systems. As a result, the standard -ljack may lead to
+# compilation failures on these systems. You can mitigate
+# this by figuring out where your distro keeps its header
+# files for pipewire's implementation of jack. For
+# example, a user of Fedora 40 would modify
+# PLATFORM_LDFLAGS to contain:
+# 	-L/usr/lib64/pipewire-0.3/jack
+# thus allowing the linker to find the appropriate headers.
 
 PLATFORM_CFLAGS = -DTEMPDIR=\"$(TEMPDIR)\" -D "NDEBUG=1" -DHAVE_JACK -MD -D "LINUX=1" -D "JUCE_CHECK_MEMORY_LEAKS=0" -D "JUCER_LINUX_MAKE_7346DA2A=1" -D "JUCE_APP_VERSION=1.0.0" -D "JUCE_APP_VERSION_HEX=0x10000"
 


### PR DESCRIPTION
New versions of GCC complain about a bad cast in the code of the JUCE library; adding the 'unsigned' keyword makes these errors go away and allows for clean compilation.

Modern distributions have now begun shipping Pipewire as a full JACK replacement, and in some cases the linker is unable to find the jack libraries provided by Pipewire. This is probably pretty distro-dependent, so I added a warning to the Linux Makefile to at least inform users that they may need to manually add library folders to PLATFORM_LDFLAGS during the compilation phase.